### PR TITLE
High Performance Carousel Example

### DIFF
--- a/.tern-project
+++ b/.tern-project
@@ -1,0 +1,20 @@
+{
+  "ecmaVersion": 5,
+  "libs": [],
+  "loadEagerly": [
+    "static/script/**",
+    "node_modules/tal/static/script/**"
+  ],
+  "dontLoad": [
+  ],
+  "plugins": {
+    "requirejs": {
+      "baseURL": "",
+      "paths": {
+        "antie": "node_modules/tal/static/script",
+        "sampleapp": "static/script"
+      },
+      "override": ""
+    }
+  }
+}

--- a/static/script/appui/components/carouselcomponent.js
+++ b/static/script/appui/components/carouselcomponent.js
@@ -1,4 +1,4 @@
-require.def("sampleapp/appui/components/carouselcomponent",
+define("sampleapp/appui/components/carouselcomponent",
     [
         "antie/widgets/component",
         "antie/datasource",

--- a/static/script/appui/components/carouselcomponent.js
+++ b/static/script/appui/components/carouselcomponent.js
@@ -42,6 +42,7 @@ define("sampleapp/appui/components/carouselcomponent",
             },
 
             onBeforeShow: function (evt) {
+                this.outputElement.id = evt.args.id;
                 this._initialItem = evt.args.initialItem || 0;
                 this._dontShowYet(evt);
                 this.setDescription(evt.args.description || "");

--- a/static/script/appui/components/horizontalprogresscomponent.js
+++ b/static/script/appui/components/horizontalprogresscomponent.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def("sampleapp/appui/components/horizontalprogresscomponent",
+define("sampleapp/appui/components/horizontalprogresscomponent",
     [
         "antie/widgets/component",
         "antie/widgets/horizontalprogress",

--- a/static/script/appui/components/simple.js
+++ b/static/script/appui/components/simple.js
@@ -31,9 +31,10 @@ define("sampleapp/appui/components/simple",
         "antie/widgets/carousel",
         "antie/datasource",
         "sampleapp/appui/formatters/simpleformatter",
-        "sampleapp/appui/datasources/simplefeed"
+        "sampleapp/appui/datasources/simplefeed",
+        "sampleapp/appui/components/simplebutton"
     ],
-    function (Component, Button, Label, VerticalList, Carousel, DataSource, SimpleFormatter, SimpleFeed) {
+    function (Component, Button, Label, VerticalList, Carousel, DataSource, SimpleFormatter, SimpleFeed, SimpleButton) {
 
         // All components extend Component
         return Component.extend({
@@ -51,7 +52,8 @@ define("sampleapp/appui/components/simple",
                 welcomeLabel = new Label("welcomeLabel", "Welcome to your first TAL application!");
                 this.appendChildWidget(welcomeLabel);
 
-                var newCarouselButton = this._createCarouselButton();
+                var simpleCarouselButton = this._createSimpleCarouselButton();
+                var hpCarouselButton = this._createHPCarouselButton();
 
                 var playerButton = new Button();
                 playerButton.addEventListener("select", function(evt){
@@ -67,7 +69,8 @@ define("sampleapp/appui/components/simple",
 
                 // Create a vertical list and append the buttons to navigate within the list
                 verticalListMenu = new VerticalList("mainMenuList");
-                verticalListMenu.appendChildWidget(newCarouselButton);
+                verticalListMenu.appendChildWidget(simpleCarouselButton);
+                verticalListMenu.appendChildWidget(hpCarouselButton);
                 verticalListMenu.appendChildWidget(playerButton);
                 verticalListMenu.appendChildWidget(horizontalProgressButton);
                 this.appendChildWidget(verticalListMenu);
@@ -86,27 +89,43 @@ define("sampleapp/appui/components/simple",
                 });
             },
 
-            _createCarouselButton: function () {
+            _createSimpleCarouselButton: function () {
                 var self = this;
                 function carouselExampleSelected() {
                     self.getCurrentApplication().pushComponent(
                         "maincontainer",
                         "sampleapp/appui/components/carouselcomponent",
-                        self._getCarouselConfig()
+                        self._getCarouselConfig("carouselComponent", Button)
                     );
                 }
 
-                var button = new Button('carouselButton');
-                button.appendChildWidget(new Label("Carousel Example"));
+                var button = new Button('simpleCarouselButton');
+                button.appendChildWidget(new Label("Simple Carousel Example"));
                 button.addEventListener('select', carouselExampleSelected);
                 return button;
             },
 
-            _getCarouselConfig: function () {
+            _createHPCarouselButton: function () {
+                var self = this;
+                function carouselExampleSelected() {
+                    self.getCurrentApplication().pushComponent(
+                        "maincontainer",
+                        "sampleapp/appui/components/carouselcomponent",
+                        self._getCarouselConfig("hpCarouselComponent", SimpleButton)
+                    );
+                }
+
+                var button = new Button('hpCarouselButton');
+                button.appendChildWidget(new Label("High Performance Carousel Example"));
+                button.addEventListener('select', carouselExampleSelected);
+                return button;
+            },
+
+            _getCarouselConfig: function (carouselName, buttonClass) {
                 return {
                     description: "Carousel example, LEFT and RIGHT to navigate, SELECT to go back",
                     dataSource: new DataSource(null, new SimpleFeed(), 'loadData'),
-                    formatter: new SimpleFormatter(),
+                    formatter: new SimpleFormatter(buttonClass),
                     orientation: Carousel.orientations.HORIZONTAL,
                     carouselId: 'verticalCullingCarousel',
                     animOptions: {
@@ -117,8 +136,9 @@ define("sampleapp/appui/components/simple",
                         normalisedWidgetAlignPoint: 0.5
                     },
                     initialItem: 4,
-                    type: "CULLING",
-                    lengths: 264
+                    type: "WRAPPING",
+                    lengths: 264,
+                    id: carouselName
                 };
             },
 

--- a/static/script/appui/components/simple.js
+++ b/static/script/appui/components/simple.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def("sampleapp/appui/components/simple",
+define("sampleapp/appui/components/simple",
     [
         "antie/widgets/component",
         "antie/widgets/button",

--- a/static/script/appui/components/simplebutton.js
+++ b/static/script/appui/components/simplebutton.js
@@ -1,0 +1,65 @@
+/**
+ * @fileOverview Requirejs module containing the antie.widgets.Button class.
+ * @preserve Copyright (c) 2013-present British Broadcasting Corporation. All rights reserved.
+ * @license See https://github.com/fmtvp/tal/blob/master/LICENSE for full licence
+ */
+
+define(
+    'sampleapp/appui/components/simplebutton',
+    [
+        'antie/widgets/button'
+    ],
+    function(Button) {
+        'use strict';
+
+        return Button.extend({
+
+            init: function(id, animationEnabled) {
+                this._super(id, animationEnabled);
+                this._blurButton();
+            },
+
+            render: function(device) {
+                this._super(device);
+
+                // Create 2 backgrounds: one for blur and one for normal, hide the focus background
+                this._blurBackground = device._createElement('div', this.id + "_blur", ["simpleButtonBackground"]);
+                this._focusBackground = device._createElement('div', this.id + "_focus", ["simpleButtonFocussedBackground"]);
+                this._focusBackground.style.opacity = 0;
+                this.outputElement.insertBefore(this._blurBackground, this.outputElement.firstChild);
+                this.outputElement.insertBefore(this._focusBackground, this.outputElement.firstChild);
+
+                return this.outputElement;
+            },
+
+            _setActiveChildFocussed: function(focus) {
+                this._super(focus);
+                if(focus) {
+                    this._focusButton();
+                } else {
+                    this._blurButton();
+                }
+            },
+
+            removeFocus: function() {
+                this._super();
+                this._blurButton();
+            },
+
+            _focusButton: function() {
+                // on focus, show focus and hide blur backgrounds
+                if (this._focusBackground === undefined)
+                  return;
+                this._focusBackground.style.opacity = 1;
+                this._blurBackground.style.opacity = 0;
+            },
+            _blurButton: function() {
+                // on blur, show blur and hide focus backgrounds
+                if (this._focusBackground === undefined)
+                  return;
+                this._focusBackground.style.opacity = 0;
+                this._blurBackground.style.opacity = 1;
+            }
+        });
+    }
+);

--- a/static/script/appui/components/simplevideocomponent.js
+++ b/static/script/appui/components/simplevideocomponent.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def("sampleapp/appui/components/simplevideocomponent",
+define("sampleapp/appui/components/simplevideocomponent",
     [
         "antie/widgets/component",
         "antie/widgets/button",

--- a/static/script/appui/datasources/simplefeed.js
+++ b/static/script/appui/datasources/simplefeed.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def("sampleapp/appui/datasources/simplefeed",
+define("sampleapp/appui/datasources/simplefeed",
     [
         "antie/class"
     ],

--- a/static/script/appui/formatters/simpleformatter.js
+++ b/static/script/appui/formatters/simpleformatter.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def("sampleapp/appui/formatters/simpleformatter",
+define("sampleapp/appui/formatters/simpleformatter",
     [
         "antie/formatter",
         "antie/widgets/label",

--- a/static/script/appui/formatters/simpleformatter.js
+++ b/static/script/appui/formatters/simpleformatter.js
@@ -26,15 +26,18 @@ define("sampleapp/appui/formatters/simpleformatter",
     [
         "antie/formatter",
         "antie/widgets/label",
-        "antie/widgets/button",
         "antie/widgets/image"
     ],
-    function(Formatter, Label, Button, Image) {
+    function(Formatter, Label, Image) {
         return Formatter.extend({
+            init: function(buttonClass) {
+                this._super();
+                this._buttonClass = buttonClass;
+            },
             format : function (iterator) {
                 var button, item;
                 item = iterator.next();
-                button = new Button("fruit" + item.id);
+                button = new this._buttonClass("fruit" + item.id);
                 button.appendChildWidget(new Image("img-item.id", item.img, { width : 200, height: 200}));
                 button.appendChildWidget(new Label(item.title));
                 return button;

--- a/static/script/appui/layouts/1080p.js
+++ b/static/script/appui/layouts/1080p.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('sampleapp/appui/layouts/1080p',
+define('sampleapp/appui/layouts/1080p',
     {
         classes: [
             "layout1080p"

--- a/static/script/appui/layouts/540p.js
+++ b/static/script/appui/layouts/540p.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('sampleapp/appui/layouts/540p',
+define('sampleapp/appui/layouts/540p',
     {
         classes: [
             "layout540p"

--- a/static/script/appui/layouts/720p.js
+++ b/static/script/appui/layouts/720p.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('sampleapp/appui/layouts/720p',
+define('sampleapp/appui/layouts/720p',
     {
         classes: [
             "layout720p"

--- a/static/script/appui/sampleapp.js
+++ b/static/script/appui/sampleapp.js
@@ -22,7 +22,7 @@
  * Please contact us for an alternative licence
  */
 
-require.def('sampleapp/appui/sampleapp',
+define('sampleapp/appui/sampleapp',
     [
         'antie/application',
         'antie/widgets/container'

--- a/static/style/base.css
+++ b/static/style/base.css
@@ -178,6 +178,36 @@ initial element background in the base stylesheet, not in dynamically loaded sty
     color: #000000;
 }
 
+.simpleButtonBackground {
+    background-color: #DCDCDC;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    z-index: -2;
+    transform: translateZ(0);
+}
+
+#hpCarouselComponent .button {
+    background-color: transparent;
+    padding: 0px;
+    transform: translateZ(0);
+    position: relative;
+}
+
+.simpleButtonFocussedBackground {
+    background-color: #FFD700;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    z-index: -1;
+    transform: translateZ(0);
+}
+
+#hpCarouselComponent .buttonFocussed {
+    transform: translateZ(0) scale(1.1);
+    z-index: 2;
+}
+
 .buttonFocussed.menuendpoint {
     background-color: #FFD700;
 }
@@ -249,16 +279,16 @@ initial element background in the base stylesheet, not in dynamically loaded sty
     display: inline-block;
 }
 
-#carouselComponent {
+#carouselComponent, #hpCarouselComponent {
     position: relative;
 }
 
-#carouselComponent > .carouselmask {
+#carouselComponent > .carouselmask, #hpCarouselComponent > .carouselmask {
     margin-left: auto;
     margin-right: auto;
 }
 
-#carouselComponent > .description {
+#carouselComponent > .description, #hpCarouselComponent> .description {
     position: static;
 }
 

--- a/static/style/layouts/540p.css
+++ b/static/style/layouts/540p.css
@@ -71,11 +71,16 @@
     width: 720px;
 }
 
-#carouselComponent > .carouselmask.vertical {
+#hpCarouselComponent > .carouselmask.horizontal {
+    width: 720px;
+    padding: 8px;
+}
+
+#carouselComponent > .carouselmask.vertical, #hpCarouselComponent > .carouselmask.vertical {
     height: 450px;
     width: 264px
 }
 
-#carouselComponent > .description {
+#carouselComponent > .description, #hpCarouselComponent > .description {
     margin-bottom: 32px;
 }

--- a/static/style/layouts/720p.css
+++ b/static/style/layouts/720p.css
@@ -70,11 +70,16 @@
     width: 960px;
 }
 
-#carouselComponent > .carouselmask.vertical {
+#hpCarouselComponent > .carouselmask.horizontal {
+    width: 960px;
+    padding: 8px;
+}
+
+#carouselComponent > .carouselmask.vertical, #hpCarouselComponent > .carouselmask.vertical {
     height: 600px;
     width: 264px
 }
 
-#carouselComponent > .description {
+#carouselComponent > .description, #hpCarouselComponent > .description {
     margin-bottom: 64px;
 }


### PR DESCRIPTION
Added an example which implements a carousel with 0 repainting (with the css transform animations enabled) done by:

1. Using a background div and switching divs to change background color instead of using the `background-color` css property.
2. Use `opacity:0` instead of `visibility:"hidden"` to show/hide carousel elements.
3. Use `transform: scale `to make the focused element bigger, instead of width/height.

Just a little experiment I did while messing around with the TAL codebase. Thought I'd share it via this PR.